### PR TITLE
add "copy" and "union" functions to ScalableBloomFilter

### DIFF
--- a/pybloom_live/pybloom.py
+++ b/pybloom_live/pybloom.py
@@ -7,6 +7,7 @@ Requires the bitarray library: http://pypi.python.org/pypi/bitarray/
 from __future__ import absolute_import
 import math
 import hashlib
+import copy
 from pybloom_live.utils import range_fn, is_string_io, running_python_3
 from struct import unpack, pack, calcsize
 
@@ -291,15 +292,6 @@ class ScalableBloomFilter(object):
         filter.add(key, skip_check=True)
         return False
 
-    def copy(self):
-        """Return a copy of this scalable bloom filter.
-        """
-        new_filter = ScalableBloomFilter(initial_capacity=self.initial_capacity,
-                                         error_rate=self.error_rate,
-                                         mode=self.SMALL_SET_GROWTH)
-        new_filter.filters = self.filters[:]
-        return new_filter
-
     def union(self, other):
         """ Calculates the union of the underlying classic bloom filters and returns
         a new scalable bloom filter object."""
@@ -310,11 +302,11 @@ class ScalableBloomFilter(object):
             raise ValueError("Unioning two scalable bloom filters requires \
             both filters to have both the same mode, initial capacity and error rate")
         if len(self.filters) > len(other.filters):
-            larger_sbf = self.copy()
-            smaller_sbf = other.copy()
+            larger_sbf = copy.deepcopy(self)
+            smaller_sbf = other
         else:
-            larger_sbf = other.copy()
-            smaller_sbf = self.copy()
+            larger_sbf = copy.deepcopy(other)
+            smaller_sbf = self
         # Union the underlying classic bloom filters
         new_filters = []
         for i in range(len(smaller_sbf.filters)):

--- a/pybloom_live/test_pybloom.py
+++ b/pybloom_live/test_pybloom.py
@@ -68,6 +68,17 @@ class TestUnionIntersection(unittest.TestCase):
             bloom_one.union(bloom_two)
         self.assertRaises(ValueError, _run)
 
+    def test_union_scalable_bloom_filter(self):
+        bloom_one = ScalableBloomFilter(mode=ScalableBloomFilter.SMALL_SET_GROWTH)
+        bloom_two = ScalableBloomFilter(mode=ScalableBloomFilter.SMALL_SET_GROWTH)
+        chars = [chr(i) for i in range_fn(97, 123)]
+        for char in chars[int(len(chars) / 2):]:
+            bloom_one.add(char)
+        for char in chars[:int(len(chars) / 2)]:
+            bloom_two.add(char)
+        new_bloom = bloom_one.union(bloom_two)
+        for char in chars:
+            self.assertTrue(char in new_bloom)
 
 class Serialization(unittest.TestCase):
     SIZE = 12345

--- a/pybloom_live/test_pybloom.py
+++ b/pybloom_live/test_pybloom.py
@@ -71,14 +71,15 @@ class TestUnionIntersection(unittest.TestCase):
     def test_union_scalable_bloom_filter(self):
         bloom_one = ScalableBloomFilter(mode=ScalableBloomFilter.SMALL_SET_GROWTH)
         bloom_two = ScalableBloomFilter(mode=ScalableBloomFilter.SMALL_SET_GROWTH)
-        chars = [chr(i) for i in range_fn(97, 123)]
-        for char in chars[int(len(chars) / 2):]:
-            bloom_one.add(char)
-        for char in chars[:int(len(chars) / 2)]:
-            bloom_two.add(char)
+        numbers = [i for i in range_fn(1, 10000)]
+        middle = int(len(numbers) / 2)
+        for number in numbers[middle:]:
+            bloom_one.add(number)
+        for number in numbers[:middle]:
+            bloom_two.add(number)
         new_bloom = bloom_one.union(bloom_two)
-        for char in chars:
-            self.assertTrue(char in new_bloom)
+        for number in numbers:
+            self.assertTrue(number in new_bloom)
 
 class Serialization(unittest.TestCase):
     SIZE = 12345


### PR DESCRIPTION
This pull request adds `union` and `copy` for ScalableBloomFilter which is required in several applications.