### PR TITLE
Remove alien commit

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,0 @@
-theme: jekyll-theme-merlot


### PR DESCRIPTION
Prior to this commit, there was an `_config.yml` checked in. I am not
able to recall the reason why it is checked in. This is the alien
commit. Now it is removed by this commit.