### PR TITLE
Added Python versions to TravisCI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,16 @@
 language: python
+matrix:
+  allow_failures:
+    - python: pypy
+    - python: 3.7-dev
 python:
   - "2.6"
   - "2.7"
   - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7-dev"
+  - "pypy"
 
 install:
   - pip install -r requirements.txt


### PR DESCRIPTION
Thought I'd add a small contribution 😄 

Wasn't sure if it runs on pypy too, so I've added it under "allow_failures" so it doesn't fail the build if not.