### PR TITLE
Fix tofile with io.BytesIO on Python 2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
 
 install:
   - pip install -r requirements.txt
-  - pip install --upgrade pytest
+  - pip install --upgrade pytest==3.6.3
 script:
   - py.test pybloom_live

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,15 @@
 language: python
-python:
-  - "2.6"
-  - "2.7"
-  - "3.4"
+matrix:
+  include:
+    - python: 2.7
+      dist: xenial
+      sudo: false
+    - python: 3.4
+      dist: trusty
+      sudo: false
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 install:
   - pip install -r requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,6 @@ python:
 
 install:
   - pip install -r requirements.txt
-  - pip install pytest
+  - pip install --upgrade pytest
 script:
   - py.test pybloom_live

--- a/pybloom_live/test_pybloom.py
+++ b/pybloom_live/test_pybloom.py
@@ -105,7 +105,7 @@ class TestSerialization:
     SIZE = 12345
     EXPECTED = set([random.randint(0, 10000100) for _ in range_fn(0, SIZE)])
 
-    @pytest.mark.parametrize("klass,args", [
+    @pytest.mark.parametrize("cls,args", [
         (BloomFilter, (SIZE,)),
         (ScalableBloomFilter, ()),
     ])
@@ -119,8 +119,8 @@ class TestSerialization:
             lambda: StringIO.StringIO,
             marks=pytest.mark.skipif(running_python_3, reason="Python 2 only")),
     ])
-    def test_serialization(self, klass, args, stream_factory):
-        filter = klass(*args)
+    def test_serialization(self, cls, args, stream_factory):
+        filter = cls(*args)
         for item in self.EXPECTED:
             filter.add(item)
 
@@ -129,7 +129,7 @@ class TestSerialization:
         del filter
 
         f.seek(0)
-        filter = klass.fromfile(f)
+        filter = cls.fromfile(f)
         for item in self.EXPECTED:
             assert item in filter
 

--- a/pybloom_live/test_pybloom.py
+++ b/pybloom_live/test_pybloom.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     from io import BytesIO as StringIO
 
+from io import BytesIO
+
 import unittest
 import random
 import tempfile
@@ -126,6 +128,20 @@ class Serialization(unittest.TestCase):
                     self.assertTrue(item in filter)
                 del(filter)
                 stream.close()
+
+    def test_bytes_io(self):
+        filter = BloomFilter(self.SIZE)
+        for item in self.EXPECTED:
+            filter.add(item)
+
+        stream = BytesIO()
+        filter.tofile(stream)
+        del filter
+        stream.seek(0)
+        filter = BloomFilter.fromfile(stream)
+        for item in self.EXPECTED:
+            assert item in filter
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pybloom_live/utils.py
+++ b/pybloom_live/utils.py
@@ -5,7 +5,9 @@ try:
     import StringIO
     import cStringIO
 except ImportError:
-    from io import BytesIO
+    pass
+
+from io import BytesIO
 
 running_python_3 = sys.version_info[0] == 3
 
@@ -18,9 +20,10 @@ def range_fn(start=0, stop=None):
 
 
 def is_string_io(instance):
-    if running_python_3:
-       return isinstance(instance, BytesIO)
-    else:
+    if isinstance(instance, BytesIO):
+        return True
+    if not running_python_3:
         return isinstance(instance, (StringIO.StringIO,
                                      cStringIO.InputType,
                                      cStringIO.OutputType))
+    return False

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34
+envlist = py27,py34,py37
 [testenv]
 deps=pytest==3.6.3
 commands=py.test pybloom_live/test_pybloom.py

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
 envlist = py26,py27,py34
 [testenv]
-deps=pytest
+deps=pytest==3.6.3
 commands=py.test pybloom_live/test_pybloom.py


### PR DESCRIPTION
The check for a memory-backed IO object assumes that Python 2 doesn't have io.BytesIO, but it does, and it should work!

Without this change, bitarray's tofile fails because it tries to access the BytesIO's backing file pointer, and it doesn't have one.

This fixes the is_string_io check and tidies up the testing a little bit.