### PR TITLE
Update benchmarks.py: Add parens around print

### DIFF
--- a/pybloom_live/benchmarks.py
+++ b/pybloom_live/benchmarks.py
@@ -18,8 +18,8 @@ def main(capacity=100000, request_error_rate=0.1):
             end - start, f.capacity / (end - start)))
     oneBits = f.bitarray.count(True)
     zeroBits = f.bitarray.count(False)
-    print "Number of 1 bits:", oneBits
-    print "Number of 0 bits:", zeroBits
+    print("Number of 1 bits:", oneBits)
+    print("Number of 0 bits:", zeroBits)
     print("Number of Filter Bits:", f.num_bits)
     print("Number of slices:", f.num_slices)
     print("Bits per slice:", f.bits_per_slice)


### PR DESCRIPTION
Installing this into a downstream Python 3.6.4 project gives me the following warning: 

```
...
Getting distribution for 'pybloom-live'.
warning: no files found matching 'ez_setup.py'
  File "build/bdist.macosx-10.13-x86_64/egg/pybloom_live/benchmarks.py", line 21
    print "Number of 1 bits:", oneBits
                            ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("Number of 1 bits:", oneBits)?

  File ".../buildout/eggs/tmpgs7sq_8h/pybloom_live-3.0.0-py3.6.egg/pybloom_live/benchmarks.py", line 21
    print "Number of 1 bits:", oneBits
                            ^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print("Number of 1 bits:", oneBits)?

Got pybloom-live 3.0.0.
...
```

Strictly speaking, this would now print differently on Python 2.x, but that doesn't appear to be required in this file from the other print statements present, i.e. it should be OK to print under for example Python 2.7.15 with the tuple form:

```
>>> print "Number of 1 bits:", 150  
Number of 1 bits: 150
>>> print("Number of 1 bits:", 150) 
('Number of 1 bits:', 150)
```