### PR TITLE
bitarray deprecated length() in favor of __len__

### DIFF
--- a/pybloom_live/pybloom.py
+++ b/pybloom_live/pybloom.py
@@ -213,8 +213,8 @@ class BloomFilter(object):
         else:
             (filter.bitarray.frombytes(f.read()) if is_string_io(f)
              else filter.bitarray.fromfile(f))
-        if filter.num_bits != filter.bitarray.length() and \
-                (filter.num_bits + (8 - filter.num_bits % 8) != filter.bitarray.length()):
+        if filter.num_bits != len(filter.bitarray) and \
+                (filter.num_bits + (8 - filter.num_bits % 8) != len(filter.bitarray)):
             raise ValueError('Bit length mismatch!')
 
         return filter


### PR DESCRIPTION
https://github.com/joseph-fox/python-bloomfilter/issues/32#issuecomment-838669830