### PR TITLE
Add support for xxhash

### DIFF
--- a/pybloom_live/benchmarks.py
+++ b/pybloom_live/benchmarks.py
@@ -1,9 +1,13 @@
 #!/usr/bin/env python
 #
 """Test performance of BloomFilter at a set capacity and error rate."""
+import math
 import sys
+import time
+
+import bitarray
+
 from pybloom import BloomFilter
-import bitarray, math, time
 from utils import range_fn
 
 

--- a/pybloom_live/pybloom.py
+++ b/pybloom_live/pybloom.py
@@ -5,11 +5,15 @@ without increasing the false positive error_rate.
 Requires the bitarray library: http://pypi.python.org/pypi/bitarray/
 """
 from __future__ import absolute_import
-import math
-import hashlib
+
 import copy
-from pybloom_live.utils import range_fn, is_string_io, running_python_3
-from struct import unpack, pack, calcsize
+import hashlib
+import math
+from struct import calcsize, pack, unpack
+
+import xxhash
+
+from pybloom_live.utils import is_string_io, range_fn, running_python_3
 
 try:
     import bitarray
@@ -34,7 +38,7 @@ def make_hashfuncs(num_slices, num_bits):
     elif total_hash_bits > 128:
         hashfn = hashlib.sha1
     else:
-        hashfn = hashlib.md5
+        hashfn = xxhash.xxh128
 
     fmt = fmt_code * (hashfn().digest_size // chunk_size)
     num_salts, extra = divmod(num_slices, len(fmt))

--- a/pybloom_live/test_pybloom.py
+++ b/pybloom_live/test_pybloom.py
@@ -1,19 +1,19 @@
 from __future__ import absolute_import
+
 from pybloom_live.pybloom import (BloomFilter, ScalableBloomFilter,
                                   make_hashfuncs)
-from pybloom_live.utils import running_python_3, range_fn
+from pybloom_live.utils import range_fn, running_python_3
 
 try:
-    import StringIO
     import cStringIO
+    import StringIO
 except ImportError:
     pass
 
 import io
-
-import unittest
 import random
 import tempfile
+import unittest
 
 import pytest
 
@@ -21,15 +21,15 @@ import pytest
 class TestMakeHashFuncs(unittest.TestCase):
     def test_make_hashfuncs_returns_hashfn(self):
         make_hashes, hashfn = make_hashfuncs(100, 20)
-        self.assertEquals('openssl_sha512', hashfn.__name__)
+        self.assertEqual('openssl_sha512', hashfn.__name__)
         make_hashes, hashfn = make_hashfuncs(20, 3)
-        self.assertEquals('openssl_sha384', hashfn.__name__)
+        self.assertEqual('openssl_sha384', hashfn.__name__)
         make_hashes, hashfn = make_hashfuncs(15, 2)
-        self.assertEquals('openssl_sha256', hashfn.__name__)
+        self.assertEqual('openssl_sha256', hashfn.__name__)
         make_hashes, hashfn = make_hashfuncs(10, 2)
-        self.assertEquals('openssl_sha1', hashfn.__name__)
+        self.assertEqual('openssl_sha1', hashfn.__name__)
         make_hashes, hashfn = make_hashfuncs(5, 1)
-        self.assertEquals('openssl_md5', hashfn.__name__)
+        self.assertEqual('xxh3_128', hashfn.__name__)
 
 
 class TestUnionIntersection(unittest.TestCase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 bitarray>=0.3.4
+xxhash>=3.0.0


### PR DESCRIPTION
This PR adds support for xxhash, one of the [fastest](https://github.com/Cyan4973/xxHash) non-cryptographic hashes. It replaces md5 hash function for 128 bits. 

Attaching benchmark runs. xxh3_128 is consistently faster than md5. As suggested in [this issue](https://github.com/joseph-fox/python-bloomfilter/issues/16), xxh3_128 can be made default in new versions of this module.

**hashfn: openssl_md5**
```
Iteration-1:
hashfn: openssl_md5
0.148 seconds to add to capacity,  674661.65 entries/second
Number of 1 bits: 271374
Number of 0 bits: 207882
Number of Filter Bits: 479256
Number of slices: 4
Bits per slice: 119814
------
Fraction of 1 bits at capacity: 0.566
0.111 seconds to check false positives,  897309.76 checks/second
Requested FP rate: 0.1000
Experimental false positive rate: 0.1048
Projected FP rate (Goel/Gupta): 0.102603
-------------------

Iteration-2:
hashfn: openssl_md5
0.154 seconds to add to capacity,  651165.07 entries/second
Number of 1 bits: 271374
Number of 0 bits: 207882
Number of Filter Bits: 479256
Number of slices: 4
Bits per slice: 119814
------
Fraction of 1 bits at capacity: 0.566
0.111 seconds to check false positives,  900389.84 checks/second
Requested FP rate: 0.1000
Experimental false positive rate: 0.1048
Projected FP rate (Goel/Gupta): 0.102603
-------------------
```

**hashfn: xxh3_128**
```
Iteration-1:
hashfn: xxh3_128
0.133 seconds to add to capacity,  751715.88 entries/second
Number of 1 bits: 271006
Number of 0 bits: 208250
Number of Filter Bits: 479256
Number of slices: 4
Bits per slice: 119814
------
Fraction of 1 bits at capacity: 0.565
0.095 seconds to check false positives, 1049305.27 checks/second
Requested FP rate: 0.1000
Experimental false positive rate: 0.1025
Projected FP rate (Goel/Gupta): 0.102603
-------------------

Iteration-2:
hashfn: xxh3_128
0.137 seconds to add to capacity,  729703.06 entries/second
Number of 1 bits: 271006
Number of 0 bits: 208250
Number of Filter Bits: 479256
Number of slices: 4
Bits per slice: 119814
------
Fraction of 1 bits at capacity: 0.565
0.094 seconds to check false positives, 1061892.13 checks/second
Requested FP rate: 0.1000
Experimental false positive rate: 0.1025
Projected FP rate (Goel/Gupta): 0.102603
-------------------

Iteration-3:
hashfn: xxh3_128
0.135 seconds to add to capacity,  738980.23 entries/second
Number of 1 bits: 271006
Number of 0 bits: 208250
Number of Filter Bits: 479256
Number of slices: 4
Bits per slice: 119814
------
Fraction of 1 bits at capacity: 0.565
0.094 seconds to check false positives, 1060439.67 checks/second
Requested FP rate: 0.1000
Experimental false positive rate: 0.1025
Projected FP rate (Goel/Gupta): 0.102603
```